### PR TITLE
Remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM nixos/nix:2.3.12
-RUN nix-env -iA nixpkgs.cachix nixpkgs.bash nixpkgs.git nixpkgs.openssl
-COPY . /pkgs
-RUN cd /pkgs && nix-build --max-jobs 4 --verbose release.nix


### PR DESCRIPTION
This was for testing, and turned out not to be very useful, since the docker layers were many GB large when run.