### PR TITLE
Update GridTools to 2.1.0 and 1.1.4

### DIFF
--- a/gridtools/1.nix
+++ b/gridtools/1.nix
@@ -6,7 +6,7 @@ stdenv.mkDerivation rec {
     owner = pname;
     repo = pname;
     rev = "eccd3e057d6deb1c97c7b6f8233ba6bf97a96622";
-    sha256 = "1mpyk85grc6zyjpjvkj29014ml5n86789068r1vj6l079yc5jw11";
+    sha256 = "x1niPXiJE0JyjWvtXiIkXmae2O5OS/YIx9EVkEAn+5g=";
   };
 
   propagatedBuildInputs = [ boost.dev ]

--- a/gridtools/1.nix
+++ b/gridtools/1.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, cmake, boost, git, cacert, llvmPackages }:
 stdenv.mkDerivation rec {
   pname = "gridtools";
-  version = "1.1.3";
+  version = "1.1.4";
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
     rev = "eccd3e057d6deb1c97c7b6f8233ba6bf97a96622";
-    sha256 = "167v4x0905fiqw4gcjsfxvc9wrjy4hi5xvbbimr444w9g0yy4nf7";
+    sha256 = "1mpyk85grc6zyjpjvkj29014ml5n86789068r1vj6l079yc5jw11";
   };
 
   propagatedBuildInputs = [ boost.dev ]

--- a/gridtools/2.nix
+++ b/gridtools/2.nix
@@ -1,12 +1,12 @@
 { stdenv, lib, fetchFromGitHub, cmake, boost, git, cacert, llvmPackages }:
 stdenv.mkDerivation rec {
   pname = "gridtools";
-  version = "2.0.0";
+  version = "2.1.0";
   src = fetchFromGitHub {
     owner = pname;
     repo = pname;
-    rev = "c9c30288e632846fa30d9cd9b5f282aa6886a887";
-    sha256 = "1k1sqzib81352xsvkzyv38bmq5k5asfjdrck274i9q27w3fp1s5r";
+    rev = "a8039cbde1552f88424690f74211acb34a7f2720";
+    sha256 = "189na3bh6zndd1jnrdjv83d7jchydhbpyl40007qjmj6kayi7h8c";
   };
 
   propagatedBuildInputs = [ boost.dev ]


### PR DESCRIPTION
Updates to the latest releases used for gt4py.