### PR TITLE
Update cachix cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     docker:
       - image: nixos/nix:2.3.12
         environment:
-          CACHIX_NAME: vulcanclimatemodeling
+          CACHIX_NAME: ai2climatemodeling
     steps:
       - checkout
       - run:
@@ -37,7 +37,7 @@ jobs:
     macos:
       xcode: 13.2.0
     environment:
-      CACHIX_NAME: vulcanclimatemodeling
+      CACHIX_NAME: ai2climatemodeling
     steps:
       - run:
           name: Install Nix

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ of the climate modeling team.
 This repo essentially pins a version of nixpkgs and defines derivations for the various packages
 that the climate modeling team develops.
 Continuous integration pushes builds to a cachix repo
-[vulcanclimatemodeling](https://app.cachix.org/cache/vulcanclimatemodeling) that can be used to
+[ai2climatemodeling](https://app.cachix.org/cache/ai2climatemodeling) that can be used to
 pull pre-built versions.
 
 ### Stable Workflow
@@ -24,7 +24,7 @@ let
   pkgs = import (builtins.fetchGit {
     # Descriptive name to make the store path easier to identify
     name = "ai2cm-packages";
-    url = "git@github.com:VulcanClimateModeling/packages.git";
+    url = "git@github.com:ai2cm/packages.git";
     ref = "master";
     # SHA of the commit of pkgs to use. This effectively pins all packages to
     # the versions specified in that commit.


### PR DESCRIPTION
Updates the package builds to use a new cachix cache. Associated with the change of keys on CircleCI from the old cache to the new one. 